### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "dependencies": {
     "node-fetch": "^2.1.2"
-  }
+  },
+  "jest": {
+    "testURL": "http://localhost/"
+  },
 }


### PR DESCRIPTION
The tests no longer work. They failed with the error: 
```
    SecurityError: localStorage is not available for opaque origins
      
      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)
```